### PR TITLE
Add basic global styles and shared page classes

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,6 @@
 export default function AboutPage() {
   return (
-    <section style={{ marginTop: "2rem" }}>
+    <section className="section">
       <h2>About</h2>
       <p>Write a short bio, your background, and what you care about.</p>
     </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,27 +2,113 @@
 
 :root {
   color-scheme: light;
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --text: #0f172a;
+  --muted: #475569;
+  --border: #e2e8f0;
+  --accent: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  min-height: 100vh;
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
-  background: #f8fafc;
-  color: #0f172a;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+  color: var(--text);
+  line-height: 1.6;
 }
 
-main {
+.site-main {
   max-width: 64rem;
   margin: 0 auto;
-  padding: 3rem 1.5rem;
+  padding: 3rem 1.25rem 4rem;
 }
 
-nav {
+.site-header {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
 }
 
-a {
-  color: inherit;
+.site-title {
+  margin: 0;
+  font-size: 1.375rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  color: var(--muted);
   text-decoration: none;
+  font-weight: 500;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.5rem;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  color: var(--accent);
+  background: rgba(37, 99, 235, 0.1);
+  outline: none;
+}
+
+.section {
+  margin-top: 2rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.875rem;
+  padding: 1.5rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+}
+
+.hero-title {
+  font-size: clamp(1.75rem, 3.5vw, 2.4rem);
+  line-height: 1.2;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.lead {
+  max-width: 48ch;
+  color: var(--muted);
+}
+
+.list-reset {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.project-item + .project-item {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px dashed var(--border);
+}
+
+.project-item p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .site-main {
+    padding-top: 2rem;
+  }
+
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,10 +14,10 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
   return (
     <html lang="en">
       <body>
-        <main>
-          <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-            <h1 style={{ margin: 0 }}>Your Name</h1>
-            <nav>
+        <main className="site-main">
+          <header className="site-header">
+            <h1 className="site-title">Your Name</h1>
+            <nav className="site-nav">
               <Link href="/">Home</Link>
               <Link href="/about">About</Link>
               <Link href="/projects">Projects</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 export default function HomePage() {
   return (
-    <section style={{ marginTop: "2rem" }}>
+    <section className="section">
       <p>Hi, I&apos;m Your Name.</p>
-      <h2 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>I build useful things for the web.</h2>
-      <p style={{ maxWidth: "48ch" }}>
+      <h2 className="hero-title">I build useful things for the web.</h2>
+      <p className="lead">
         This starter is scaffolded with Next.js App Router, TypeScript, Tailwind, and MDX-ready config.
       </p>
     </section>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -5,11 +5,11 @@ const projects = [
 
 export default function ProjectsPage() {
   return (
-    <section style={{ marginTop: "2rem" }}>
+    <section className="section">
       <h2>Projects</h2>
-      <ul>
+      <ul className="list-reset">
         {projects.map((project) => (
-          <li key={project.name} style={{ marginBottom: "1rem" }}>
+          <li key={project.name} className="project-item">
             <strong>{project.name}</strong>
             <p>{project.description}</p>
           </li>


### PR DESCRIPTION
### Motivation
- Provide a consistent visual foundation and replace inline page styles with reusable CSS so the site has a baseline design system. 
- Centralize layout, header, navigation, and card/section styles to simplify future visual changes and theming. 
- Improve mobile behavior by adding a simple responsive breakpoint for the header.

### Description
- Expanded `src/app/globals.css` with CSS variables, typography and layout defaults, header/nav rules, reusable `section`/`hero-title`/`lead`/`list-reset`/`project-item` classes, and a mobile breakpoint. 
- Refactored `src/app/layout.tsx` to use the shared classes (`site-main`, `site-header`, `site-nav`, `site-title`) instead of inline styles. 
- Updated `src/app/page.tsx`, `src/app/about/page.tsx`, and `src/app/projects/page.tsx` to use the new shared classes for consistent appearance. 
- Changes provide a small visual baseline without introducing new dependencies.

### Testing
- Ran `npm run lint`, which failed due to unresolved local dependency resolution for `eslint-config-next` in this environment. 
- Attempted `npm install`/`npm ci`, which did not complete successfully in this environment and left `next`/other binaries unavailable. 
- Attempted `npm run build` and `npm run dev`, both of which failed because the `next` binary was not present from the incomplete dependency installation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3c0b4a3e4833298a0311547206798)